### PR TITLE
Add docstrings and comments to sampler

### DIFF
--- a/nanovllm/layers/sampler.py
+++ b/nanovllm/layers/sampler.py
@@ -5,13 +5,17 @@ from torch import nn
 class Sampler(nn.Module):
 
     def __init__(self):
+        """Initialise le module Sampler."""
         super().__init__()
 
     def forward(self, logits: torch.Tensor, temperatures: torch.Tensor):
+        """Echantillonne un jeton en fonction des logits et des températures."""
         logits = logits.to(torch.float)
-        greedy_tokens = logits.argmax(dim=-1)
-        logits.div_(temperatures.unsqueeze(dim=1))
+        greedy_tokens = logits.argmax(dim=-1)  # jeton le plus probable
+        logits.div_(temperatures.unsqueeze(dim=1))  # applique la température
         probs = torch.softmax(logits, dim=-1, dtype=torch.float)
         # logprobs = torch.log_softmax(logits, dim=-1, dtype=torch.float)
+        # bruit de Gumbel pour échantillonner selon la distribution
         sample_tokens = probs.div_(torch.empty_like(probs).exponential_(1)).argmax(dim=-1)
+        # choix gourmand si température nulle, sinon échantillon
         return torch.where(temperatures == 0, greedy_tokens, sample_tokens)


### PR DESCRIPTION
## Summary
- add French docstrings to `Sampler` methods
- clarify temperature scaling and token selection logic with inline comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ead523f883259b2e41170f916ac5